### PR TITLE
optional autofill of forms on mobile

### DIFF
--- a/data/settings-panel.html
+++ b/data/settings-panel.html
@@ -48,6 +48,9 @@
         <td colspan=2><input type="checkbox" id="ignorePath"><small>Ignore path for site matching</small></td>
       </tr>
       <tr>
+        <td colspan=2><input type="checkbox" id="autofillMobile"><small>Autofill forms on Firefox Mobile</small></td>
+      </tr>
+      <tr>
         <td colspan=2 align="center"><input type="submit" id="save" value="Save"><input type="submit" id="cancel" value="Cancel"></td>
       </tr>
     </table>

--- a/data/settings-panel.js
+++ b/data/settings-panel.js
@@ -9,6 +9,7 @@ var inputIncludeName = document.getElementById("includeName");
 var inputIgnoreProtocol = document.getElementById("ignoreProtocol");
 var inputIgnoreSubdomain = document.getElementById("ignoreSubdomain");
 var inputIgnorePath = document.getElementById("ignorePath");
+var inputAutofillMobile = document.getElementById("autofillMobile");
 var warningRemember = document.getElementById("rememberWarning");
 var warningHost = document.getElementById("hostWarning");
 
@@ -22,7 +23,8 @@ function saveSettings() {
     "includeName": inputIncludeName.checked,
     "ignoreProtocol": inputIgnoreProtocol.checked,
     "ignoreSubdomain": inputIgnoreSubdomain.checked,
-    "ignorePath": inputIgnorePath.checked
+    "ignorePath": inputIgnorePath.checked,
+    "autofillMobile": inputAutofillMobile.checked
   };
   self.port.emit("saveSettings", settings);
 }

--- a/index.js
+++ b/index.js
@@ -152,6 +152,13 @@ function processLoginList() {
   }
   if (mobile) {
     populateFillMenu();
+
+    if(simplePrefs.prefs["autofillMobile"]){
+      var worker = tabs.activeTab.attach({
+	    contentScriptFile: self.data.url("fill-password.js")
+      });
+	  worker.port.emit("fillPassword", userList[0], passwordList[0]);
+    }
   }
 }
 


### PR DESCRIPTION
Hey, nice plugin, thanks a lot :)
I'm using it on Firefox Mobile and filling in the login details needs three clicks and some scrolling.

It would be nice to have an autofill option on FF Mobile.

I think this code might do it, but I don't really know how to test it, so i didn't...
It just takes the first Account and fills that in, which probably is the most common usecase.

I think in general Autofill should be avoided, but filling the form on mobile is just too hard.
It would be nice to hide the option on Desktop FF, but I couldn't figure out how.